### PR TITLE
Fix Tutorial Back Button

### DIFF
--- a/GS/tutorial.cpp
+++ b/GS/tutorial.cpp
@@ -19,8 +19,6 @@ Tutorial::~Tutorial()
 void Tutorial::on_pushButton_2_clicked()
 {
 
-    MainWindow *mainwindow = new MainWindow();
     this -> close();
-    mainwindow->showFullScreen();
 
 }


### PR DESCRIPTION
Tutorial back button was slow because it was creating a new mainwindow
object.
