### PR TITLE
clock on mission execution

### DIFF
--- a/GS/UAV-Forge-New.pro
+++ b/GS/UAV-Forge-New.pro
@@ -46,7 +46,8 @@ SOURCES += main.cpp\
     ActionPacket.cpp \
     InfoPacket.cpp \
     TelemetryPacket.cpp \
-    Packet.cpp
+    Packet.cpp \
+    digitalclock.cpp
 QMAKE_MAC_SDK = macosx10.9
 HEADERS  += mainwindow.h \
     options.h \
@@ -69,7 +70,8 @@ HEADERS  += mainwindow.h \
     infopacket.h \
     telemetrypacket.h \
     ackpacket.h \
-    packet.h
+    packet.h \
+    digitalclock.h
 
 FORMS    += mainwindow.ui \
     options.ui \

--- a/GS/digitalclock.cpp
+++ b/GS/digitalclock.cpp
@@ -1,0 +1,52 @@
+#include "digitalclock.h"
+
+#include <QtWidgets>
+
+#include "digitalclock.h"
+
+DigitalClock::DigitalClock(QWidget *parent)
+    : QPlainTextEdit(parent)
+{
+    //setSegmentStyle(Filled);
+
+
+
+    //setWindowTitle(tr("Digital Clock"));
+    //resize(150, 60);
+}
+
+/**
+ * @brief DigitalClock::initiate
+ * saves start time (need to fix to get from message box)
+ * connects 1 second timer to showtime function
+ */
+void DigitalClock::initiate(QTime timein)
+{
+    start = QTime::currentTime().toString("hh:mm:ss");
+    time = timein;
+    QTimer *timer = new QTimer(this);
+    connect(timer, SIGNAL(timeout()), this, SLOT(showTime()));
+    timer->start(1000);
+
+    showTime();
+}
+
+/**
+ * @brief DigitalClock::showTime
+ * creates string from elapsed time and starting time
+ * clears the PlainText and updates it
+ */
+void DigitalClock::showTime()
+{
+    QString text;
+    text = "Started: ";
+    text.append(start);
+    text.append("\nElapsed: ");
+    int elapsed = time.elapsed();
+    elapsed = elapsed;
+    QTime time2(00, 00, 00);
+    time2 = time2.addMSecs(elapsed);
+    text.append(time2.toString("hh:mm:ss"));
+    clear();
+    appendPlainText(text);
+}

--- a/GS/digitalclock.h
+++ b/GS/digitalclock.h
@@ -1,0 +1,30 @@
+#ifndef DIGITALCLOCK_H
+#define DIGITALCLOCK_H
+
+
+#include <QPlainTextEdit>
+#include <QTime>
+#include <QTimer>
+
+/**
+ * @brief The DigitalClock class
+ * inherits from QPlainTextEdit
+ * -Aaron Ko
+ */
+class DigitalClock : public QPlainTextEdit
+{
+    Q_OBJECT
+
+public:
+    DigitalClock(QWidget *parent = 0);
+
+    QTime time;
+    QString start;
+
+    void initiate(QTime timein);
+
+private slots:
+    void showTime();
+};
+
+#endif // DIGITALCLOCK_H

--- a/GS/mapexecution.cpp
+++ b/GS/mapexecution.cpp
@@ -27,6 +27,8 @@ MapExecution::MapExecution(QList<QString> strings, QWidget *parent) : QDialog(pa
     buttonGroup = new QButtonGroup();
 
     messagebox messagebox;
+    //initate clock timer
+    ui->clock->initiate(messagebox.timer);
     messagebox.fetch_from_table(strings);
     std::vector<Protocol::ActionPacket> test_actions = messagebox.get_action_packets();
     int pack_number = 1;

--- a/GS/mapexecution.h
+++ b/GS/mapexecution.h
@@ -10,6 +10,7 @@
 #include <QPair>
 #include <QList>
 
+#include "digitalclock.h"
 #include "gsclient.h"
 #include "gsserver.h"
 #include "tablemodel.h"

--- a/GS/mapexecution.ui
+++ b/GS/mapexecution.ui
@@ -175,26 +175,13 @@
        <bool>true</bool>
       </property>
      </widget>
-     <widget class="QPushButton" name="colorTester">
-      <property name="geometry">
-       <rect>
-        <x>60</x>
-        <y>40</y>
-        <width>75</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Test</string>
-      </property>
-     </widget>
      <widget class="QPlainTextEdit" name="StatusConsole">
       <property name="geometry">
        <rect>
-        <x>3</x>
-        <y>70</y>
-        <width>191</width>
-        <height>211</height>
+        <x>0</x>
+        <y>90</y>
+        <width>201</width>
+        <height>241</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -210,10 +197,28 @@
        <bool>true</bool>
       </property>
      </widget>
-     <zorder>StatusIndicator</zorder>
-     <zorder>colorTester</zorder>
-     <zorder>StatusConsole</zorder>
-     <zorder>CurrentData</zorder>
+     <widget class="DigitalClock" name="clock">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>40</y>
+        <width>201</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="sizeAdjustPolicy">
+       <enum>QAbstractScrollArea::AdjustIgnored</enum>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
     </widget>
    </item>
    <item row="4" column="0">
@@ -399,6 +404,11 @@ border: none;
    <class>QWebView</class>
    <extends>QWidget</extends>
    <header>QtWebKitWidgets/QWebView</header>
+  </customwidget>
+  <customwidget>
+   <class>DigitalClock</class>
+   <extends>QPlainTextEdit</extends>
+   <header>digitalclock.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/GS/messagebox.h
+++ b/GS/messagebox.h
@@ -27,9 +27,11 @@
 #include "infopacket.h"
 #include "telemetrypacket.h"
 
+
 class messagebox
 {
 public:
+    friend class DigitalClock;
     messagebox();
     void fetch_from_table(QList<QString> tableList);
     void load_ack_packet(uint8_t* buffer, size_t len);
@@ -63,9 +65,10 @@ public:
     void addActionPacket(const Protocol::ActionPacket& actionPacket);
     void addTelemetryPacket(const Protocol::TelemetryPacket& telemPacket);
     void addInfoPacket(const Protocol::InfoPacket& infoPacket);
+    QTime timer; //Qtime that starts when message box is created
 
 private:
-    QTime timer; //Qtime that starts when message box is created
+
 
     /**
      * @brief Takes timestamp form timer and subtracts the offset determined form UAV timestamp


### PR DESCRIPTION
Added clock cpp and clock.h derived from -http://doc.qt.io/qt-5/qtwidgets-widgets-digitalclock-example.html
displays on mission execution
still need to get a more precise start time (possibly)
and sometimes elapsed skips digits
-Aaron Ko 1/28/2016
