### PR TITLE
Removed vertical header from MapPlanning. 

### DIFF
--- a/GS/mapplanning.ui
+++ b/GS/mapplanning.ui
@@ -161,6 +161,9 @@ border: none;
      <property name="frameShadow">
       <enum>QFrame::Plain</enum>
      </property>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Cells now start at the very left of the table. There is no ugly grey age on the left now.
